### PR TITLE
Add missing dc namespace

### DIFF
--- a/check-lwn.py
+++ b/check-lwn.py
@@ -112,6 +112,7 @@ rss = f'''\
   xmlns="http://purl.org/rss/1.0/"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:syn="http://purl.org/rss/1.0/modules/syndication/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
   xmlns:atom="http://www.w3.org/2005/Atom"
 >
   <channel rdf:about="{os.environ['FEED_URL']}">


### PR DESCRIPTION
My rss reader is currently unable to parse this feed. Adding the dc namespace fixes this.