### PR TITLE
Fix missing paid articles

### DIFF
--- a/check-lwn.py
+++ b/check-lwn.py
@@ -140,27 +140,35 @@ def main() -> None:
     ET.SubElement(channel, '{http://www.w3.org/2005/Atom}link', {'href': websub_hub_url, 'rel': 'hub'})
 
     now = datetime.datetime.now(datetime.timezone.utc)
-
-    ## local_articles -= expired_local_articles
-    ## RSS_output += local_articles.filter(available)
-    expire_dt = now - datetime.timedelta(days=3)
     rss_output = {}
-    for article_id, local_article in list(local_articles.items()):
-        if local_article.pub_date < expire_dt:
-            del local_articles[article_id]
-        elif local_article.pub_date <= now:
-            rss_output[article_id] = (local_article.pub_date, article_id, local_article)
 
     ## RSS_output += remote_articles.filter(available)
     ## local_articles += remote_articles.filter(under_paywall)
+    ## local_articles -= remote_articles.filter(not under_paywall)
+    ## sometimes, whether an article is under paywall may change
+    ## we prioritize remote state over local
     for item in remote_article_xml_list:
         remote_article = Article(item)
         article_id = remote_article.id
-        article_under_paywall = remote_article.check_paywall()
+        article_under_paywall = remote_article.check_paywall() # article.pub_date updated according to paywall
         if article_under_paywall:
             local_articles[article_id] = remote_article
         else:
             rss_output[article_id] = (remote_article.pub_date, article_id, remote_article)
+            local_articles.pop(article_id, None)
+
+    ## local_articles -= local_articles.filter(expired)
+    ## RSS_output += local_articles.filter(available)
+    ## remote RSS keep articles for 3 or 4 days
+    ## paywall lasts 1 week
+    ## we keep articles previously under paywall for an extra 3 days
+    ## (unless they are moved out of paywall earlier than expected)
+    expire = now - datetime.timedelta(days=3)
+    for article_id, local_article in list(local_articles.items()):
+        if local_article.pub_date < expire:
+            del local_articles[article_id]
+        elif local_article.pub_date <= now:
+            rss_output[article_id] = (local_article.pub_date, article_id, local_article)
 
     ## sort output items by pub_date descending, then article_id descending
     ## add output items into RSS skeleton

--- a/check-lwn.py
+++ b/check-lwn.py
@@ -142,19 +142,13 @@ def main() -> None:
     now = datetime.datetime.now(datetime.timezone.utc)
 
     ## local_articles -= expired_local_articles
-    expire_dt = now + datetime.timedelta(days=3)
-    expired_article_ids = []
-    for article_id, local_article in local_articles.items():
-        if local_article.pub_date >= expire_dt:
-            expired_article_ids.append(article_id)
-    for article_id in expired_article_ids:
-        del local_articles[article_id]
-
-    rss_output = {}
-
     ## RSS_output += local_articles.filter(available)
-    for article_id, local_article in local_articles.items():
-        if local_article.pub_date <= now:
+    expire_dt = now - datetime.timedelta(days=3)
+    rss_output = {}
+    for article_id, local_article in list(local_articles.items()):
+        if local_article.pub_date < expire_dt:
+            del local_articles[article_id]
+        elif local_article.pub_date <= now:
             rss_output[article_id] = (local_article.pub_date, article_id, local_article)
 
     ## RSS_output += remote_articles.filter(available)
@@ -167,11 +161,10 @@ def main() -> None:
             local_articles[article_id] = remote_article
         else:
             rss_output[article_id] = (remote_article.pub_date, article_id, remote_article)
-            local_articles.pop(article_id, None)
 
-    ## sort output items by pub_date ascending, then article_id ascending
+    ## sort output items by pub_date descending, then article_id descending
     ## add output items into RSS skeleton
-    for _, _, item in sorted(list(rss_output.values())):
+    for _, _, item in sorted(list(rss_output.values()), reverse=True):
         channel.append(item.xml)
 
     ## RSS output


### PR DESCRIPTION
The logic for removing expired articles from the articles.json file is flawed. The expire_dt variable is set to 3 days in the future instead of 3 days in the past. This causes any paid articles that will be released in more than 3 days to be removed from the file. This also means that any article that makes it past this check and is added to the feed is never removed. This can be seen by viewing the contains of the feed. There are over 400 articles ranging from back to 2024 still being served. This also explains why the articles.json and rss.xml files are both over 400kb. I have also reversed the sorting order of the feed, since this is how lwn sorts their feed and it seems to be the default order of sorting for rss feeds. I used 3 days as the time limit for serving paid articles, since this is was it seems like the intended use of the 3 day offset in expire_dt was meant for, but if this needs be to changed let me know.